### PR TITLE
refactor(projects): Add property locale and sort by name

### DIFF
--- a/src/Project.js
+++ b/src/Project.js
@@ -14,11 +14,12 @@ module.exports = (conn, ProjectSchema) => {
             id: { $first: '$_id' },
             slug: { $first: '$slug' },
             name: { $first: '$title' },
+            locale: { $first: '$locale' },
             latestVersion: { $first: '$version' },
             versions: { $push: '$version' },
           },
         },
-        { $sort: { _id: 1 } },
+        { $sort: { name: 1 } },
       ])
         .then(docs => docs.map(({ id, ...doc }) => ({ ...doc, _id: id })));
   };

--- a/test/__snapshots__/Project.spec.js.snap
+++ b/test/__snapshots__/Project.spec.js.snap
@@ -4,15 +4,7 @@ exports[`Project should be able to query projects latest version of each project
 Array [
   Object {
     "latestVersion": "2.0.0",
-    "name": "Cifrado César",
-    "slug": "cipher-1",
-    "versions": Array [
-      "2.0.0",
-      "1.0.0",
-    ],
-  },
-  Object {
-    "latestVersion": "2.0.0",
+    "locale": "es-ES",
     "name": "Cifrado César",
     "slug": "cipher-2",
     "versions": Array [
@@ -22,9 +14,20 @@ Array [
   },
   Object {
     "latestVersion": "1.0.0",
+    "locale": "es-ES",
     "name": "Cifrado César",
     "slug": "cipher-3",
     "versions": Array [
+      "1.0.0",
+    ],
+  },
+  Object {
+    "latestVersion": "2.0.0",
+    "locale": "es-ES",
+    "name": "Cifrado César",
+    "slug": "cipher-1",
+    "versions": Array [
+      "2.0.0",
       "1.0.0",
     ],
   },


### PR DESCRIPTION
Se añade la propiedad `locale` para el feature del `lms` se necesita este atributo para diferencias los projects entre idiomas ya que algunos tienen el mismo nombre.

Y se hace un ordenamiento por nombre.

![image](https://user-images.githubusercontent.com/25912510/69574868-3280c680-0f97-11ea-95bb-e4c901582b1f.png)
