### PR TITLE
feat(users): Set "state" key to "student" by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@laboratoria/models",
-  "version": "1.0.0-alpha.24",
+  "version": "1.0.0-alpha.25",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/schemas/AcademicProfileSchema.js
+++ b/src/schemas/AcademicProfileSchema.js
@@ -12,6 +12,7 @@ module.exports = (conn) => {
     state: {
       index: true,
       type: String,
+      default: 'student',
       enum: ['inJobPlacement', 'inOutplacement', 'notWantToWork', 'working', 'student'],
     },
   });

--- a/src/schemas/UserSchema.js
+++ b/src/schemas/UserSchema.js
@@ -118,7 +118,10 @@ module.exports = (conn) => {
     // paymentStart: Date,
     // NOTE: ????
     // currentJob: String, // Reference to UserJob collection
-    academicProfile: AcademicProfileSchema(conn),
+    academicProfile: {
+      default: {},
+      type: AcademicProfileSchema(conn),
+    },
   }, {
     toJSON: { virtuals: true },
     toObject: { virtuals: true },


### PR DESCRIPTION
__Context__

Lately, we have replaced the `available` key in [GraduateProfileSchema](https://github.com/Laboratoria/models/blob/master/src/schemas/GraduateProfileSchema.js) for a new key `state` in [AcademicProfileSchema](https://github.com/Laboratoria/models/blob/master/src/schemas/AcademicProfileSchema.js#L12), which is part of [UserSchema](https://github.com/Laboratoria/models/blob/master/src/schemas/UserSchema.js), obviously this change brings breaking changes for our datamodel, that's why we should be prepared for.

So, After talking with @chamodev, @MaiaRojas and @bouli we've found convenient to set the `state` key with the `student` value by default for all the existing users and new ones.

This PR is intended to take care of new users.