### PR TITLE
Add timestamps (createdAt, updatedAt) keys to user schema.

### DIFF
--- a/src/__tests__/User.spec.js
+++ b/src/__tests__/User.spec.js
@@ -74,20 +74,21 @@ describe('User', () => {
     await project.save();
   });
 
-  it('should ony require uid, email and name??', () => {
+  it('should ony require uid, email', () => {
     const doc = new User({
       uid: 'abcdefghijklmnopqrstuvwxyz1',
       email: 'other@somewhere.com',
-      name: 'other',
     });
 
     return doc.save()
       .then((result) => {
         expect(result.uid).toBe('abcdefghijklmnopqrstuvwxyz1');
         expect(result.email).toBe('other@somewhere.com');
-        expect(result.name).toBe('other');
         expect(Array.isArray(result.roles)).toBe(true);
         expect(result.roles.length).toBe(0);
+        expect(result.createdAt instanceof Date).toBeTruthy();
+        expect(result.updatedAt instanceof Date).toBeTruthy();
+        expect(result.academicProfile.state).toBe('student');
       });
   });
 

--- a/src/schemas/UserSchema.js
+++ b/src/schemas/UserSchema.js
@@ -49,7 +49,7 @@ module.exports = (conn) => {
       index: true,
       unique: true,
     },
-    name: {
+    name: { // should it be required??
       type: String,
       trim: true,
     },
@@ -123,6 +123,7 @@ module.exports = (conn) => {
       type: AcademicProfileSchema(conn),
     },
   }, {
+    timestamps: true,
     toJSON: { virtuals: true },
     toObject: { virtuals: true },
   });


### PR DESCRIPTION
Timestamp like `createdAt` and `updatedAt` come in handy for queries based on time

__Use cases??__

In Admission team, we needed to query all users that got signed up after migration, but we couldn't do it using only our database (MongoDB) because we don't have any key to identify when a user was created.