### PR TITLE
feat: Add cohort to experiments and hasExperiments to cohorts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@laboratoria/models",
-  "version": "1.0.0-alpha.29",
+  "version": "1.0.0-alpha.31",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/__tests__/Experiment.spec.js
+++ b/src/__tests__/Experiment.spec.js
@@ -38,6 +38,7 @@ describe('Experiment', () => {
       slug: 'text',
       name: 'text',
       description: 'prueba text',
+      cohort: mongoose.Types.ObjectId('7967ec06c8931404bd672e36'),
     });
 
     return experiment.save()

--- a/src/__tests__/__snapshots__/Cohort.spec.js.snap
+++ b/src/__tests__/__snapshots__/Cohort.spec.js.snap
@@ -4,8 +4,8 @@ exports[`Cohort should create common core cohort for a given generation 1`] = `
 Object {
   "__v": 0,
   "generation": 1,
+  "hasExperiments": false,
   "name": "am",
-  "organization": null,
   "program": "bc",
   "publicAdmission": false,
   "rubric": "2",

--- a/src/__tests__/__snapshots__/Experiment.spec.js.snap
+++ b/src/__tests__/__snapshots__/Experiment.spec.js.snap
@@ -2,12 +2,14 @@
 
 exports[`Experiment should fail when experiment has fields missing 1`] = `
 Object {
+  "cohort": [ValidatorError: Path \`cohort\` is required.],
   "description": [ValidatorError: Path \`description\` is required.],
 }
 `;
 
 exports[`Experiment should fail with missing props 1`] = `
 Object {
+  "cohort": [ValidatorError: Path \`cohort\` is required.],
   "createdBy": [ValidatorError: Path \`createdBy\` is required.],
   "description": [ValidatorError: Path \`description\` is required.],
   "name": [ValidatorError: Path \`name\` is required.],

--- a/src/schemas/CohortSchema.js
+++ b/src/schemas/CohortSchema.js
@@ -38,13 +38,17 @@ module.exports = (conn) => {
     organization: {
       type: conn.Schema.Types.ObjectId,
       ref: 'Organization',
-      default: null,
     },
     state: {
       index: true,
       type: String,
       default: 'inProgress',
       enum: ['inProgress', 'closed'],
+    },
+    hasExperiments: {
+      type: Boolean,
+      default: false,
+      required: true,
     },
   }, {
     timestamps: { createdAt: true, updatedAt: true },

--- a/src/schemas/Experimentation/ExperimentSchema.js
+++ b/src/schemas/Experimentation/ExperimentSchema.js
@@ -14,6 +14,11 @@ module.exports = (conn) => {
     iterations: [ExperimentIterationSchema(conn)],
     active: { type: Boolean, required: true, default: true },
     lastVersion: { type: Number, required: true, default: 0 },
+    cohort: {
+      type: conn.Schema.Types.ObjectId,
+      ref: 'Cohort',
+      required: true,
+    },
   }, { collection: 'experiments', timestamps: true });
 
   return ExperimentSchema;

--- a/src/schemas/__tests__/Experimentation/ExperimentSchema.spec.js
+++ b/src/schemas/__tests__/Experimentation/ExperimentSchema.spec.js
@@ -14,6 +14,7 @@ describe('ExperimentSchema', () => {
       slug: 'text',
       name: 'text',
       description: 'prueba text',
+      cohort: mongoose.Types.ObjectId('7967ec06c8931404bd672e36'),
     }, ExperimentSchema);
     return doc.validate();
   });
@@ -27,6 +28,7 @@ describe('ExperimentSchema', () => {
       description: 'prueba text',
       active: false,
       lastVersion: 2,
+      cohort: mongoose.Types.ObjectId('7967ec06c8931404bd672e36'),
     }, ExperimentSchema);
     return doc.validate();
   });

--- a/src/schemas/__tests__/Experimentation/__snapshots__/ExperimentSchema.spec.js.snap
+++ b/src/schemas/__tests__/Experimentation/__snapshots__/ExperimentSchema.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`ExperimentSchema should fail validation when fields missing 1`] = `
 Object {
+  "cohort": [ValidatorError: Path \`cohort\` is required.],
   "createdBy": [ValidatorError: Path \`createdBy\` is required.],
   "description": [ValidatorError: Path \`description\` is required.],
   "name": [ValidatorError: Path \`name\` is required.],


### PR DESCRIPTION
In Corporate Training, we would like admins to enable experiments in selected cohorts — this PR adds `hasExperiments` to cohorts. And adds `cohort` to experiments. 